### PR TITLE
各種センサーで検出した人のマージ順序を変えトラッキング精度を向上

### DIFF
--- a/detection/spencer_detected_person_association/launch/fuse_lasers_and_rgbd.launch
+++ b/detection/spencer_detected_person_association/launch/fuse_lasers_and_rgbd.launch
@@ -9,73 +9,45 @@
         -->
 
         <!-- Fuse lasers with upper-body. Both have reliable depth estimates, so we can fuse in Euclidean space -->
-<!--         <node name="fuse_lasers_and_rgbd_upper_body" pkg="nodelet" type="nodelet" args="load spencer_detected_person_association/EuclideanNNFuserNodelet detected_person_association_nodelet_manager" output="screen">
-            <param name="detection_id_increment" value="20"/>
-            <param name="detection_id_offset" value="11"/>
-            <param name="fused_radial_weight_for_topic1" value="0.95"/>
-            <param name="fused_radial_weight_for_topic2" value="0.05"/>
+        <node name="fuse_lasers_and_rgbd_upper_body" pkg="nodelet" type="nodelet" args="load spencer_detected_person_association/EuclideanNNFuserNodelet detected_person_association_nodelet_manager" output="screen">
+            <param name="detection_id_increment" value="20" />
+            <param name="detection_id_offset" value="11" />
+            <param name="fused_radial_weight_for_topic1" value="0.95" />
+            <param name="fused_radial_weight_for_topic2" value="0.05" />
             <rosparam param="input_topics">
                 - composite/lasers_aggregated
                 - composite/rgbd_upper_body_aggregated
             </rosparam>
-            <remap from="output" to="composite/lasers_upper_body_fused"/>
+            <remap from="output" to="composite/lasers_upper_body_fused" />
         </node>
 
-         <node name="fuse_lasers_upper_body_and_face" pkg="nodelet" type="nodelet" args="load spencer_detected_person_association/EuclideanNNFuserNodelet detected_person_association_nodelet_manager" output="screen">
-            <param name="detection_id_increment" value="20"/>
-            <param name="detection_id_offset" value="12"/>
-            <param name="fused_radial_weight_for_topic1" value="0.95"/>
-            <param name="fused_radial_weight_for_topic2" value="0.05"/>
+        <node name="fuse_lasers_upper_body_and_face" pkg="nodelet" type="nodelet" args="load spencer_detected_person_association/EuclideanNNFuserNodelet detected_person_association_nodelet_manager" output="screen">
+            <param name="detection_id_increment" value="20" />
+            <param name="detection_id_offset" value="12" />
+            <param name="fused_radial_weight_for_topic1" value="0.95" />
+            <param name="fused_radial_weight_for_topic2" value="0.05" />
             <rosparam param="input_topics">
                 - composite/lasers_upper_body_fused
                 - composite/faces_aggregated
             </rosparam>
-            <remap from="output" to="composite/lasers_upper_body_face_fused"/>
+            <remap from="output" to="composite/lasers_upper_body_face_fused" />
         </node>
- -->
-
-
-         <node name="fuse_face_and_body" pkg="nodelet" type="nodelet" args="load spencer_detected_person_association/EuclideanNNFuserNodelet detected_person_association_nodelet_manager" output="screen" launch-prefix="nice -n 20">
-            <param name="detection_id_increment" value="20"/>
-            <param name="detection_id_offset" value="11"/>
-            <param name="fused_radial_weight_for_topic1" value="0.5"/>
-            <param name="fused_radial_weight_for_topic2" value="0.5"/>
-            <rosparam param="input_topics">
-                - composite/faces_aggregated
-                - composite/rgbd_upper_body_aggregated
-            </rosparam>
-            <remap from="output" to="composite/face_body_fused"/>
-        </node>
-
-         <node name="fuse_lasers_and_facebody" pkg="nodelet" type="nodelet" args="load spencer_detected_person_association/EuclideanNNFuserNodelet detected_person_association_nodelet_manager" output="screen" launch-prefix="nice -n 20">
-            <param name="detection_id_increment" value="20"/>
-            <param name="detection_id_offset" value="12"/>
-            <param name="fused_radial_weight_for_topic1" value="0.95"/>
-            <param name="fused_radial_weight_for_topic2" value="0.05"/>
-            <rosparam param="input_topics">
-                - composite/lasers_aggregated
-                - composite/face_body_fused
-            </rosparam>
-            <remap from="output" to="composite/lasers_upper_body_face_fused"/>
-        </node>
-
-        <!-- Output intermediate fused composites as DetectedPersons for visualization purposes -->
         <node name="convert_fused_lasers_upper_body_to_detections" type="composite_detections_to_detections.py" pkg="spencer_detected_person_association" launch-prefix="nice -n 20">
-            <remap from="/spencer/perception/detected_persons_composite" to="composite/lasers_upper_body_fused"/>
-            <remap from="/spencer/perception/detected_persons" to="lasers_upper_body_fused"/>
-        </node>  
+            <remap from="/spencer/perception/detected_persons_composite" to="composite/lasers_upper_body_face_fused" />
+            <remap from="/spencer/perception/detected_persons" to="lasers_upper_body_face_fused" />
+        </node>
 
         <!-- Fuse result with groundHOG, which has unreliable depth estimates, thus we should fuse in polar space -->
         <node name="fuse_lasers_upper_body_and_ground_hog" pkg="nodelet" type="nodelet" args="load spencer_detected_person_association/PolarNNFuserNodelet detected_person_association_nodelet_manager" output="screen" launch-prefix="nice -n 20">
-            <param name="detection_id_increment" value="20"/>
-            <param name="detection_id_offset" value="12"/>
-            <param name="fused_radial_weight_for_topic1" value="0.95"/>
-            <param name="fused_radial_weight_for_topic2" value="0.05"/>
+            <param name="detection_id_increment" value="20" />
+            <param name="detection_id_offset" value="12" />
+            <param name="fused_radial_weight_for_topic1" value="0.95" />
+            <param name="fused_radial_weight_for_topic2" value="0.05" />
             <rosparam param="input_topics">
                 - composite/lasers_upper_body_fused
                 - composite/rgbd_ground_hog_aggregated
             </rosparam>
-            <remap from="output" to="composite/lasers_upper_body_ground_hog_fused"/>
+            <remap from="output" to="composite/lasers_upper_body_ground_hog_fused" />
         </node>
 
     </group>

--- a/detection/spencer_detected_person_association/launch/fuse_lasers_and_rgbd.launch
+++ b/detection/spencer_detected_person_association/launch/fuse_lasers_and_rgbd.launch
@@ -1,7 +1,7 @@
 <!-- Fuses front and rear laser by simple aggregation. -->
 <launch>
     <group ns="/spencer/perception_internal/detected_person_association">
-        <!-- 
+        <!--
             We need to fuse the following topics, which are already aggregated over front and rear sensor array:
             - composite/lasers_aggregated
             - composite/rgbd_upper_body_aggregated
@@ -24,8 +24,8 @@
         <node name="fuse_lasers_upper_body_and_face" pkg="nodelet" type="nodelet" args="load spencer_detected_person_association/EuclideanNNFuserNodelet detected_person_association_nodelet_manager" output="screen">
             <param name="detection_id_increment" value="20" />
             <param name="detection_id_offset" value="12" />
-            <param name="fused_radial_weight_for_topic1" value="0.95" />
-            <param name="fused_radial_weight_for_topic2" value="0.05" />
+            <param name="fused_radial_weight_for_topic1" value="0.99" />
+            <param name="fused_radial_weight_for_topic2" value="0.01" />
             <rosparam param="input_topics">
                 - composite/lasers_upper_body_fused
                 - composite/faces_aggregated


### PR DESCRIPTION
今までは距離精度の低いupper bodyとcobの顔検出を先にfuseし(重み1:1)、
その後距離精度の高いlaserとfuseしていた(重み laser:body_and_face 19:1)。
upper bodyと顔のfuseがあまりうまくいかないためか顔検出をONにするとtracked personがなかなか現れなくなっていた。

そのため、laserとupper bodyを先にfuseし、その後顔をfuseすることで、
顔検出を入れない場合と同等のトラッキングができるように修正しました。